### PR TITLE
fix android package name issue

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -56,7 +56,7 @@
         <preference name="ROLLBAR_ENVIRONMENT" />
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="CDVRollbar">
-                <param name="android-package" value="cordova.plugin.rollbar.CDVRollbar" />
+                <param name="android-package" value="resgrid.cordova.plugin.rollbar.CDVRollbar" />
                 <param name="onload" value="true" />
             </feature>
         </config-file>
@@ -85,4 +85,3 @@
     </platform>
 
 </plugin>
-

--- a/plugin.xml
+++ b/plugin.xml
@@ -56,7 +56,7 @@
         <preference name="ROLLBAR_ENVIRONMENT" />
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="CDVRollbar">
-                <param name="android-package" value="cordova.plugin.rollbar.CDVRollbar" />
+                <param name="android-package" value="cordova.plugins.rollbar.CDVRollbar" />
                 <param name="onload" value="true" />
             </feature>
         </config-file>
@@ -80,7 +80,7 @@
         <source-file src="src/android/RollbarSDK/rollbar-android-0.1.2.jar" target-dir="libs/" framework="true"/>
 
         <!-- cordova plugin src files -->
-        <source-file src="src/android/resgrid/cordova/plugins/CDVRollbar.java" target-dir="src/cordova/plugins/rollbar" />
+        <source-file src="src/android/resgrid/cordova/plugins/CDVRollbar.java" target-dir="src/resgrid/cordova/plugins/rollbar" />
 
     </platform>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -56,7 +56,7 @@
         <preference name="ROLLBAR_ENVIRONMENT" />
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="CDVRollbar">
-                <param name="android-package" value="resgrid.cordova.plugin.rollbar.CDVRollbar" />
+                <param name="android-package" value="cordova.plugin.rollbar.CDVRollbar" />
                 <param name="onload" value="true" />
             </feature>
         </config-file>
@@ -80,7 +80,7 @@
         <source-file src="src/android/RollbarSDK/rollbar-android-0.1.2.jar" target-dir="libs/" framework="true"/>
 
         <!-- cordova plugin src files -->
-        <source-file src="src/android/resgrid/cordova/plugins/CDVRollbar.java" target-dir="src/resgrid/cordova/plugins/rollbar" />
+        <source-file src="src/android/resgrid/cordova/plugins/CDVRollbar.java" target-dir="src/cordova/plugins/rollbar" />
 
     </platform>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -56,7 +56,7 @@
         <preference name="ROLLBAR_ENVIRONMENT" />
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="CDVRollbar">
-                <param name="android-package" value="cordova.plugins.rollbar.CDVRollbar" />
+                <param name="android-package" value="resgrid.cordova.plugins.rollbar.CDVRollbar" />
                 <param name="onload" value="true" />
             </feature>
         </config-file>


### PR DESCRIPTION
Hi Emily,

Thank you for opening sourcing the plugin and we use here at Shipt.

We discovered following error with in your new updates.

`java.lang.ClassNotFoundException: cordova.plugin.rollbar.CDVRollbar`

The reference to android-package name were set to `cordova.plugin.rollbar.CDVRollbar` where as the file exists at `resgrid.cordova.plugins.rollbar.CDVRollbar`